### PR TITLE
FEATURE: custom key combos for copy operations and dev updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ WORKDIR /fastql
 COPY package*.json ./
 
 # Install Java and build tools for node-pty
-RUN apt-get update && \
+RUN apt-get update > /dev/null && \
     apt-get install -y --no-install-recommends \
-    openjdk-17-jdk python3 g++ make \
+    openjdk-17-jdk python3 g++ make > /dev/null  \
     && rm -rf /var/lib/apt/lists/* && apt-get clean
 
 # Production release

--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ It may take a few seconds for `sqlcl` to start, but you should see the default s
 
 > [!IMPORTANT]
 > Since FaStQL runs in a Docker container, a volume mount is needed to exchange data between the host and the container, which is done in the compose config.
-> 
+>
 > As soon as you start the container, a folder named output will appear in the PWD.
-> 
+>
 > The same folder exists in the container as well.
-> 
+>
 > To avoid data loss, FaStQL always prepends `output/` to paths you input using the GUI.
 
 **Terminal:**
@@ -123,13 +123,15 @@ It may take a few seconds for `sqlcl` to start, but you should see the default s
 
   - Spool OFF:
     - Pressing this button will save all output generated since Spool ON was activated to the specified file.
-   
+
 - **CLEAR**
 
   - This button clears the console.
 
 > [!TIP]
-> `Ctrl + C` and `Ctrl + V` key combinations do not work (like in most terminals). Use the right-click menu.
+> Use `Ctrl + C` and `Ctrl + Shift + V` key combinations or the right-click menu to perform copy and paste actions.
+>
+> `Ctrl + Shift + C` also triggers a copy action, but opens the browser inspector as well.
 
 ---
 
@@ -146,6 +148,6 @@ It may take a few seconds for `sqlcl` to start, but you should see the default s
 ## Legal
 
 `sqlcl` is licensed under the Oracle Free Use Terms and Conditions.
-The full text of this license is published on https://www.oracle.com/downloads/licenses/oracle-free-license.html
+The full text of this license is published [here](https://www.oracle.com/downloads/licenses/oracle-free-license.html).
 
 FaStQL (excluding SQLcl) is licensed under the [Apache 2.0 License](https://github.com/BrNi05/FaStQL/blob/main/LICENSE).

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^5.5.3",
         "husky": "^9.1.7",
-        "jiti": "^2.5.1",
         "prettier": "^3.6.2",
         "webpack": "^5.101.3",
         "webpack-cli": "^6.0.1"
@@ -2169,6 +2168,8 @@
       "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^5.5.3",
     "husky": "^9.1.7",
-    "jiti": "^2.5.1",
     "prettier": "^3.6.2",
     "webpack": "^5.101.3",
     "webpack-cli": "^6.0.1"

--- a/public/index.html
+++ b/public/index.html
@@ -43,5 +43,12 @@
   </div>
 
   <script src="bundle.js"></script>
+
+  <script>
+    const title = document.getElementById('title');
+    title.addEventListener('click', () => {
+      location.reload();
+    });
+  </script>
 </body>
 </html>

--- a/scripts/release-docker.js
+++ b/scripts/release-docker.js
@@ -9,11 +9,11 @@ const { version } = pkg;
 
 const tags = ['fastql:latest', 'brni05/fastql:latest', `brni05/fastql:${version}`];
 
-console.log('\nBuilding Docker image with tags:', tags.join(', '));
+console.log('\nBuilding Docker image with tags:', tags.join(', '), '\n');
 execSync(`docker build ${tags.map((t) => '-t ' + t).join(' ')} .`, { stdio: 'inherit' });
 
 tags.slice(1).forEach((tag) => {
-  console.log('Pushing Docker tag: ', tag);
+  console.log('\nPushing Docker tag: ', tag);
   execSync(`docker push ${tag}`, { stdio: 'inherit' });
-  console.log('\nDone pushing tag:', tag);
+  console.log('Done pushing tag:', tag);
 });

--- a/src/frontend/terminal.js
+++ b/src/frontend/terminal.js
@@ -28,6 +28,20 @@ function fitWithMargin(marginCols = 2) {
 window.addEventListener('resize', () => fitWithMargin());
 fitWithMargin();
 
+// Copy (Ctrl+C)
+term.attachCustomKeyEventHandler((event) => {
+  if (event.ctrlKey && event.key.toLowerCase() === 'c') {
+    const selection = term.getSelection();
+    if (selection) {
+      navigator.clipboard.writeText(selection);
+    }
+
+    return false; // Prevent default behavior
+  }
+
+  return true; // Allow all other events
+});
+
 // Forward SQLcl output to terminal
 socket.on('output', (data) => {
   term.write(data);


### PR DESCRIPTION
<!-- Keep the title short, clear, and descriptive -->

## Changes

Ctrl+C now copies the selected content from the terminal. Default Ctrl+C behavior is ignored.
Reduced logging for Docker-related processes.
Changed README

## Related Issues

Fixes #4 

## Testing

FaStQL runs and works.
FaStQL can be built by Docker, logging is optimal.

## Checklist

- [x] The added code is well-structured and follows best practices
- [x] The added code is documented (where needed)
- [x] The code executes and FaStQL is useable
- [x] No new issue is introduced
